### PR TITLE
Removed unused file types in the gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,10 +98,6 @@ local.properties
 .sonar/
 *.exec
 
-code/fortmocks/.project
-
-code/parent/.project
-
 *.scssc
 
 target/


### PR DESCRIPTION
I removed unused file types for the gitingore file. I copied the gitignore file from one of my previous projects and I saw that there were still some traces of it in your gitignore file.
